### PR TITLE
Improve serializer performance by 25%

### DIFF
--- a/Core/ZeroCopyBuffer.fs
+++ b/Core/ZeroCopyBuffer.fs
@@ -2,6 +2,7 @@
 
 open System
 
+
 /// <summary>
 /// Stream-like object backed by caller-supplied ArraySegment.
 ///
@@ -16,38 +17,38 @@ open System
 /// ArraySegment, without copying the associated bytes to a new Array.
 /// System.IO.MemoryStream can't do that.  Plus, the Stream API requires
 /// additional error checking.
+///
+/// TODO: Should this optionally growable?  If so, then by how much?
 
-type ZeroCopyBufferBase (seg:ArraySegment<byte>) =
+type ZeroCopyBuffer (seg:ArraySegment<byte>) =
+    let m_array = seg.Array
+    let mutable m_position = uint32 seg.Offset
+    let m_limit = uint32 seg.Offset + uint32 seg.Count 
 
-    member val Array = seg.Array with get
-    member val Position = uint32 seg.Offset with get,set
-    member val Limit = uint32 seg.Offset + uint32 seg.Count with get
-
-    new ( backing : byte array ) =
-        ZeroCopyBufferBase(ArraySegment(backing))
+    member x.Array = m_array 
+    member x.Position = m_position
 
     member x.IsEof
-        with get() = x.Position >= x.Limit
+        with get() = m_position >= m_limit
 
-/// Readable ZeroCopyBuffer (see @ZeroCopyBufferBase)
-type ZeroCopyReadBuffer (seg:ArraySegment<byte>) =
-    inherit ZeroCopyBufferBase(seg)
+    new (o:ZeroCopyBuffer) =
+        ZeroCopyBuffer( o.Array )
 
-    new (o:ZeroCopyBufferBase) =
-        ZeroCopyReadBuffer( o.Array )
+    new (backing : byte array) =
+        ZeroCopyBuffer(ArraySegment(backing))
 
-    new (backing : byte array ) =
-        ZeroCopyReadBuffer(ArraySegment(backing))
+    new size =
+        ZeroCopyBuffer(Array.zeroCreate size)
 
     // Return portion of buffer still unread as an ArraySegment
     member x.Remainder
-        with get() = ArraySegment( seg.Array, int x.Position, int <| x.Limit - x.Position )
+        with get() = ArraySegment( seg.Array, int m_position, int <| m_limit - m_position )
 
     /// Read one byte from the backing buffer.
     member x.ReadByte () =
-        if x.Position < x.Limit then
-            let b = x.Array.[int x.Position]
-            x.Position <- x.Position + 1u
+        if m_position < m_limit then
+            let b = m_array.[int m_position]
+            m_position <- m_position + 1u
             b
         else
             raise <| ProtobufWireFormatException("Read past end of protobuf buffer")
@@ -55,58 +56,43 @@ type ZeroCopyReadBuffer (seg:ArraySegment<byte>) =
     /// Read multiple bytes, returning an ArraySegment which points directly
     /// into the backing buffer.
     member x.ReadByteSegment (n:uint32) =
-        if x.Position + n <= x.Limit then
-            let buf = ArraySegment( x.Array, int x.Position, int n)
-            x.Position <- x.Position + n
+        if m_position + n <= m_limit then
+            let buf = ArraySegment( m_array, int m_position, int n)
+            m_position <- m_position + n
             buf
         else
             raise <| ProtobufWireFormatException("Read past end of protobuf buffer")
 
-/// Writable ZeroCopyBuffer (see @ZeroCopyBufferBase)
-///
-/// TODO: Should this optionally growable?  If so, then by how much?
-type ZeroCopyWriteBuffer (seg:ArraySegment<byte>) =
-    inherit ZeroCopyBufferBase(seg)
-
-    new (o:ZeroCopyBufferBase) =
-        ZeroCopyWriteBuffer( o.Array )
-
-    new (backing : byte array) =
-        ZeroCopyWriteBuffer(ArraySegment(backing))
-
-    new size =
-        ZeroCopyWriteBuffer(Array.zeroCreate size)
-
     // Return portion of buffer written as an ArraySegment
     member x.AsArraySegment
-        with get() = ArraySegment( seg.Array, seg.Offset, int x.Position - seg.Offset )
+        with get() = ArraySegment( seg.Array, seg.Offset, int m_position - seg.Offset )
 
     // Return portion of buffer written as an Array (mainly for testing)
     member x.ToArray() =
-        seg.Array.[ seg.Offset .. int x.Position - 1 ]
+        seg.Array.[ seg.Offset .. int m_position - 1 ]
 
     abstract WriteByte : byte -> unit
     abstract WriteByteSegment : uint32 -> (ArraySegment<byte>->unit) -> unit
 
     /// Write one byte into the backing buffer.
     override x.WriteByte b =
-        if x.Position < x.Limit then
-            x.Array.[int x.Position] <- b
-            x.Position <- x.Position + 1u
+        if m_position < m_limit then
+            m_array.[int m_position] <- b
+            m_position <- m_position + 1u
         else
             raise <| ProtobufWireFormatException("Write past end of protobuf buffer")
 
     /// Write 'len' bytes, via the caller supplied emplace function,
     /// directly into the backing buffer.
     override x.WriteByteSegment (len:uint32) (emplace:ArraySegment<byte>->unit) =
-        if x.Position + len <= x.Limit then
-            let buf = ArraySegment( x.Array, int x.Position, int len )
+        if m_position + len <= m_limit then
+            let buf = ArraySegment( m_array, int m_position, int len )
             emplace buf
-            x.Position <- x.Position + len
+            m_position <- m_position + len
         else
             raise <| ProtobufWireFormatException("Write past end of protobuf buffer")
 
-/// Null ZeroCopyWriteBuffer.  Used to calculate serialized length, without
+/// Null ZeroCopyBuffer.  Used to calculate serialized length, without
 /// actually writing anything.
 //
 // Note: This class simplifies the serialization logic, because a single code
@@ -114,12 +100,14 @@ type ZeroCopyWriteBuffer (seg:ArraySegment<byte>) =
 // this probably does cost a bit of performance.
 
 type NullWriteBuffer() =
-    inherit ZeroCopyWriteBuffer(0)
+    inherit ZeroCopyBuffer(0)
+
+    let mutable m_length = 0u
 
     override x.WriteByte b =
-        x.Position <- x.Position + 1u
+        m_length <- m_length + 1u
 
     override x.WriteByteSegment (len:uint32) (_:ArraySegment<byte>->unit) =
-        x.Position <- x.Position + len
+        m_length <- m_length + len
 
-    member x.Length = x.Position
+    member x.Length = m_length

--- a/Froto.Core.Test/ExampleProtoClass.fs
+++ b/Froto.Core.Test/ExampleProtoClass.fs
@@ -12,6 +12,17 @@ type InnerMessage () =
     let m_packedFixed32 = ref List.empty
     let m_repeatedInt32 = ref List.empty
 
+    let m_decoderRing =
+        [
+            1, m_id             |> Serializer.hydrateInt32
+            2, m_name           |> Serializer.hydrateString
+            3, m_option         |> Serializer.hydrateBool
+            4, m_test           |> Serializer.hydrateEnum
+            5, m_packedFixed32  |> Serializer.hydratePackedFixed32
+            6, m_repeatedInt32  |> Serializer.hydrateRepeated Serializer.hydrateInt32
+        ]
+        |> Map.ofList
+
     member x.ID             with get() = !m_id and set(v) = m_id := v
     member x.Name           with get() = !m_name and set(v) = m_name := v
     member x.bOption        with get() = !m_option and set(v) = m_option := v
@@ -27,18 +38,8 @@ type InnerMessage () =
         m_packedFixed32 := List.empty
         m_repeatedInt32 := List.empty
 
-    override x.DecoderRing =
-        [
-            1, m_id             |> Serializer.hydrateInt32
-            2, m_name           |> Serializer.hydrateString
-            3, m_option         |> Serializer.hydrateBool
-            4, m_test           |> Serializer.hydrateEnum
-            5, m_packedFixed32  |> Serializer.hydratePackedFixed32
-            6, m_repeatedInt32  |> Serializer.hydrateRepeated Serializer.hydrateInt32
-        ]
-        |> Map.ofList
-
-    override x.EncoderRing(zcb) =
+    override x.DecoderRing = m_decoderRing
+    override x.Encode(zcb) =
         let encode =
             (!m_id            |> Serializer.dehydrateVarint 1) >>
             (!m_name          |> Serializer.dehydrateString 2) >>
@@ -61,25 +62,69 @@ and ETest =
 type OuterMessage() =
     inherit MessageBase()
     let m_inner = ref None
-
-    member x.Inner with get() = !m_inner and set(v) = m_inner := v
-
-    override x.Clear() =
-        m_inner := None
-
-    override x.DecoderRing =
+    let m_decoderRing =
         [
             42, m_inner |> Serializer.hydrateOptionalMessage (InnerMessage.FromArraySegment)
         ]
         |> Map.ofList
 
-    override x.EncoderRing(zcb) =
+    override x.Clear() =
+        m_inner := None
+
+    override x.DecoderRing = m_decoderRing
+
+    override x.Encode(zcb) =
         let encode =
             (!m_inner |> Serializer.dehydrateOptionalMessage 42)
         encode zcb
+
+    member x.Inner with get() = !m_inner and set(v) = m_inner := v
 
     static member FromArraySegment (buf:System.ArraySegment<byte>) =
         let self = OuterMessage()
         self.Merge(buf) |> ignore
         self
+
+module PerformanceTest =
+
+    open Xunit
+    open FsUnit.Xunit
+
+    [<Fact>]
+    let ``Test Serialization and Deserialization Performance`` () =
+        let xs =
+            [
+                for id = 1 to 1000 do
+                    let inner = InnerMessage()
+                    inner.ID <- 1
+                    inner.Name <- "Jerry Smith"
+                    inner.bOption <- true
+                    inner.Test <- ETest.Two
+                    inner.PackedFixed32 <- [1u; 2u; 3u; 4u]
+                    inner.RepeatedInt32 <- [5;6;7;8;9]
+                    yield inner
+            ]
+
+        let len =
+            xs |> List.sumBy (fun x -> x.SerializedLengthDelimitedLength)
+
+        let buf : byte array = Array.zeroCreate (len |> int)
+        let bufAS = System.ArraySegment(buf)
+        let zcw = Froto.Core.ZeroCopyBuffer(bufAS)
+
+        xs
+        |> List.iter (fun x -> zcw |> x.SerializeLengthDelimited |> ignore)
+
+        let ys =
+            let zcr = Froto.Core.ZeroCopyBuffer(zcw.Array)
+            seq {
+                while not zcr.IsEof do
+                    let m = InnerMessage()
+                    m.DeserializeLengthDelimited(zcr) |> ignore
+                    yield m
+            }
+
+        ys |> Seq.iter ignore
+
+        1 |> should equal 1
 

--- a/Froto.Core.Test/TestSerializer.fs
+++ b/Froto.Core.Test/TestSerializer.fs
@@ -291,7 +291,7 @@ module Deserialize =
 module Serialize =
     open Froto.Core.Encoding.Serializer
 
-    type ZCB = ZeroCopyWriteBuffer
+    type ZCB = ZeroCopyBuffer
     let toArray(zcb:ZCB) = zcb.ToArray()
 
     let fid = 1 // field ID

--- a/Froto.Core.Test/TestWireFormat.fs
+++ b/Froto.Core.Test/TestWireFormat.fs
@@ -18,7 +18,7 @@ module Helpers =
 module Decode =
     open Helpers
 
-    type ZCR = ZeroCopyReadBuffer
+    type ZCR = ZeroCopyBuffer
 
     let toArray (a:ArraySegment<byte>) =
         a.ToArray()
@@ -125,7 +125,7 @@ module Decode =
 module Encode =
     open Helpers
 
-    type ZCW = ZeroCopyWriteBuffer
+    type ZCW = ZeroCopyBuffer
 
     let toArray (a:ZCW) =
         a.ToArray()
@@ -176,13 +176,13 @@ module Encode =
     let ``Encode Single and Double`` () =
         ZCW(4)
             |> encodeSingle 2.0f
-            |> ZeroCopyReadBuffer
+            |> ZeroCopyBuffer
             |> decodeSingle
             |> should equal 2.0f
 
         ZCW(8)
             |> encodeDouble 0.10
-            |> ZeroCopyReadBuffer
+            |> ZeroCopyBuffer
             |> decodeDouble
             |> should equal 0.10
 
@@ -203,7 +203,7 @@ module Encode =
 module DecodeField =
     open Helpers
 
-    type ZCR = ZeroCopyReadBuffer
+    type ZCR = ZeroCopyBuffer
 
     [<Fact>]
     let ``Read tag`` () =
@@ -293,7 +293,7 @@ module DecodeField =
 module EncodeField =
     open Helpers
 
-    type ZCW = ZeroCopyWriteBuffer
+    type ZCW = ZeroCopyBuffer
 
     let toArray (a:ZCW) = a.ToArray()
 

--- a/Froto.Core.Test/TestZeroCopyBuffer.fs
+++ b/Froto.Core.Test/TestZeroCopyBuffer.fs
@@ -15,7 +15,7 @@ type System.ArraySegment<'a>
 
 [<Fact>]
 let ``Can read bytes`` () =
-    let zc = ZeroCopyReadBuffer( [| 3uy; 2uy; 1uy |] )
+    let zc = ZeroCopyBuffer( [| 3uy; 2uy; 1uy |] )
 
     let a = zc.ReadByte()
     a |> should equal 3uy
@@ -31,7 +31,7 @@ let ``Can read bytes`` () =
 
 [<Fact>]
 let ``Can read range`` () =
-    let zc = ZeroCopyReadBuffer([| 3uy; 2uy; 1uy |])
+    let zc = ZeroCopyBuffer([| 3uy; 2uy; 1uy |])
 
     let r = zc.ReadByteSegment(2u)
     r.Count |> should equal 2
@@ -52,7 +52,7 @@ let ``Can read range`` () =
 
 [<Fact>]
 let ``Can write bytes`` () =
-    let zc = ZeroCopyWriteBuffer([| 3uy; 2uy; 1uy |])
+    let zc = ZeroCopyBuffer([| 3uy; 2uy; 1uy |])
 
     zc.WriteByte(42uy)
     zc.WriteByte(43uy)
@@ -77,7 +77,7 @@ let ``Can write range`` () =
     let emplace (dest:ArraySegment<byte>) =
         Array.Copy( xs, 0L, dest.Array, int64 dest.Offset, int64 len)
 
-    let zc = ZeroCopyWriteBuffer(256)
+    let zc = ZeroCopyBuffer(256)
     zc.WriteByteSegment (uint32 len) emplace
 
     zc.ToArray()

--- a/Froto.sln
+++ b/Froto.sln
@@ -22,6 +22,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 		build.fsx = build.fsx
 		paket.dependencies = paket.dependencies
 		paket.lock = paket.lock
+		Performance1.psess = Performance1.psess
 		readme.md = readme.md
 		release_notes.md = release_notes.md
 	EndProjectSection
@@ -54,6 +55,9 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "protobuf", "protobuf", "{82
 	EndProjectSection
 EndProject
 Global
+	GlobalSection(Performance) = preSolution
+		HasPerformanceSessions = true
+	EndGlobalSection
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
 		Release|Any CPU = Release|Any CPU


### PR DESCRIPTION
In reference to code gen in #15, note the change to build the decoder ring in the constructor, rather than every time the message is deserialized.  Also note the method name change from EncoderRing to Encode.

Would be even better to make the decoder ring a static... just thought of that.