### PR TITLE
Fix issue #35 - message is not copied in result of `hydrateRepeated`

### DIFF
--- a/Froto.Core.Test/ExampleProtoClass.fs
+++ b/Froto.Core.Test/ExampleProtoClass.fs
@@ -46,7 +46,7 @@ type InnerMessage () =
             3, m_option         |> Serializer.hydrateBool
             4, m_test           |> Serializer.hydrateEnum
             5, m_packedFixed32  |> Serializer.hydratePackedFixed32
-            6, m_repeatedInt32  |> Serializer.hydrateRepeated Serializer.hydrateInt32
+            6, m_repeatedInt32  |> Serializer.hydrateOneRepeatedInstance Serializer.hydrateInt32
         ]
         |> Map.ofList
 


### PR DESCRIPTION
NOTE: O(n^2) Performance Problem!!!

While this fixes #35, it also introduces an O(n^2) performance problem, because hydrateRepeated must keep fields in order.  The perf problem will be filed as a separate bug.

As a quick fix, this check-in appends to the end of the list.  Doing a List.rev is more invasive, because MessageBase will need to add an abstract "fixup-after-deserialization" method to reverse all repeated fields in the message.  Another fix may be to change all repeated fields to ResizeArray.