### PR TITLE
Record serialization refinement

### DIFF
--- a/Serialization.Test/ExampleProtoRecord.fs
+++ b/Serialization.Test/ExampleProtoRecord.fs
@@ -2,8 +2,6 @@
 
 module SampleNamespace =
     open System
-    open Froto.Serialization
-    open Froto.Serialization.Serializer
     open Froto.Serialization.Encoding
 
     type ETest =
@@ -102,20 +100,20 @@ module PerformanceTest =
             ]
 
         let len =
-            xs |> List.sumBy (fun x -> Serializer.serializedLengthLD x)
+            xs |> List.sumBy (fun x -> Serialize.serializedLengthLD x)
 
         let buf : byte array = Array.zeroCreate (len |> int)
         let bufAS = System.ArraySegment(buf)
         let zcw = Froto.Serialization.ZeroCopyBuffer(bufAS)
 
         xs
-        |> List.iter (fun x -> zcw |> Serializer.serializeToLD x |> ignore)
+        |> List.iter (fun x -> zcw |> Serialize.toZcbLD x |> ignore)
 
         let ys =
             let zcr = Froto.Serialization.ZeroCopyBuffer(zcw.Array)
             seq {
                 while not zcr.IsEof do
-                    yield zcr |> Serializer.deserializeFromLD InnerSample.Default
+                    yield zcr |> Deserialize.fromZcbLD InnerSample.Default
             }
 
         ys |> Seq.iter ignore

--- a/release_notes.md
+++ b/release_notes.md
@@ -1,7 +1,10 @@
 
-### 0.3.0 _ under construction
+### 0.4.0 _ under construction
   * [#3](https://github.com/ctaggart/froto/issues/3) F# type provider
   * [#15](https://github.com/ctaggart/froto/issues/15) froto.exe code generator for proto3
+
+
+### 0.3.0 _ 2016-06
   * [#37](https://github.com/ctaggart/froto/issues/38) Fix bug: O(n^2) Performance Problem on repeated fields
   * [#38](https://github.com/ctaggart/froto/issues/38) Record Serialization
   * Reimplement Class serialization using the new Record Serialization structure


### PR DESCRIPTION
Refinement to #38, F# Record Serialization.

Previous PR #39 exposed to client a set of non-specific names for functions to serialize and deserialize data.
```
Serializer.serializeTo (for ZeroCopyBuffer)
Serializer.serialize (for ArraySegment)
Serializer.deserializerFrom (for ZeroCopyBuffer)
Serializer.deserialize (for ArraySegment)
```

This PR refines those calls and names them according to the following pattern:
```
Serialize.toZeroCopyBuffer (with alias Serialize.toZcb)
Serialize.toZeroCopyBufferLengthDelimited (with alias Serialize.toZcbLD)
Serialize.toArraySegment
Serialize.toArray
Deserialize.fromZeroCopyBuffer (alias fromZcb)
Deserialize.fromZeroCopyBufferLengthDelimited (alias fromZcbLD)
Deserialize.fromArraySegment
Deserialize.fromArray
Etc.
```