### PR TITLE
Fix build on Mono

### DIFF
--- a/build.fsx
+++ b/build.fsx
@@ -65,7 +65,6 @@ Target "UnitTest" <| fun _ ->
         { p with
             IncludeTraits = ["Kind", "Unit"]
             XmlOutputPath = Some @"bin/UnitTest.xml"
-            Parallel = ParallelMode.All
         })
         dlls
 
@@ -134,6 +133,8 @@ Target "NuGet" <| fun _ ->
         OutputPath = "bin"
     }) "Compiler/Froto.Compiler.nuspec"
 
+Target "Default" DoNothing
+
 // chain targets together only on AppVeyor
 //let (==>) a b = a =?> (b, isAppVeyorBuild)
 
@@ -143,6 +144,7 @@ Target "NuGet" <| fun _ ->
 ==> "Build"
 ==> "UnitTest"
 =?> ("SourceLink", isAppVeyorBuild)
-==> "NuGet"
+=?> ("NuGet", not isMono)
+==> "Default"
 
-RunTargetOrDefault "NuGet"
+RunTargetOrDefault "Default"


### PR DESCRIPTION
As mentioned in #43, `xunit.console.exe` might fail when running in parallel mode on mono, so in order to avoid that I disabled parallel tests execution. I also disabled NuGet package creation on mono.

So now simple invocation of `./build.sh` gives a green build.