### PR TITLE
Fix bug #45 - Encoding of fixed and sfixed types

### DIFF
--- a/Serialization.Test/ExampleProtoClass.fs
+++ b/Serialization.Test/ExampleProtoClass.fs
@@ -129,7 +129,9 @@ module PerformanceTest =
     let ``Test Serialization and Deserialization Performance`` () =
         let xs =
             [
-                for id = 1 to 1000 do
+                // let count = 10000
+                let count = 100
+                for id = 1 to count do
                     let inner =
                         InnerMessage(
                             Id=1,

--- a/Serialization.Test/ExampleProtoRecord.fs
+++ b/Serialization.Test/ExampleProtoRecord.fs
@@ -1,4 +1,4 @@
-﻿module SampleProtoRecord
+﻿module ExampleProtoRecord
 
 module SampleNamespace =
     open System
@@ -85,7 +85,9 @@ module PerformanceTest =
     let ``Test Serialization and Deserialization Performance`` () =
         let xs =
             [
-                for id = 1 to 1000 do
+                // let count = 10000
+                let count = 100
+                for id = 1 to count do
                     let inner = {
                         id=1
                         name="Jerry Smith"

--- a/Serialization.Test/TestEncoding.fs
+++ b/Serialization.Test/TestEncoding.fs
@@ -315,14 +315,28 @@ module Encode =
     [<Fact>]
     let ``Encode Fixed32`` () =
         ZCB(5)
-        |> Encode.fromFixed32 fid 5
+        |> Encode.fromFixed32 fid 5u
         |> toArray
         |> should equal [| 0x08uy ||| 5uy; 5uy;0uy;0uy;0uy |]
 
     [<Fact>]
     let ``Encode Fixed64`` () =
         ZCB(9)
-        |> Encode.fromFixed64 fid 5
+        |> Encode.fromFixed64 fid 5UL
+        |> toArray
+        |> should equal [| 0x08uy ||| 1uy; 5uy;0uy;0uy;0uy; 0uy;0uy;0uy;0uy |]
+
+    [<Fact>]
+    let ``Encode SFixed32`` () =
+        ZCB(5)
+        |> Encode.fromSFixed32 fid 5
+        |> toArray
+        |> should equal [| 0x08uy ||| 5uy; 5uy;0uy;0uy;0uy |]
+
+    [<Fact>]
+    let ``Encode SFixed64`` () =
+        ZCB(9)
+        |> Encode.fromSFixed64 fid 5L
         |> toArray
         |> should equal [| 0x08uy ||| 1uy; 5uy;0uy;0uy;0uy; 0uy;0uy;0uy;0uy |]
 
@@ -373,8 +387,10 @@ module Encode =
         checkGetsElided <| Encode.fromDefaultedSInt32 2 fid 2
         checkGetsElided <| Encode.fromDefaultedSInt64 3L fid 3L
         checkGetsElided <| Encode.fromDefaultedBool true fid true
-        checkGetsElided <| Encode.fromDefaultedFixed32 4 fid 4
-        checkGetsElided <| Encode.fromDefaultedFixed64 5L fid 5L
+        checkGetsElided <| Encode.fromDefaultedFixed32 4u fid 4u
+        checkGetsElided <| Encode.fromDefaultedFixed64 5UL fid 5UL
+        checkGetsElided <| Encode.fromDefaultedSFixed32 4 fid 4
+        checkGetsElided <| Encode.fromDefaultedSFixed64 5L fid 5L
         checkGetsElided <| Encode.fromDefaultedSingle 0.60f fid 0.60f
         checkGetsElided <| Encode.fromDefaultedDouble 0.70 fid 0.70
         checkGetsElided <| Encode.fromDefaultedString "Hello" fid "Hello"
@@ -411,15 +427,29 @@ module Encode =
     [<Fact>]
     let ``Encode Packed Fixed32`` () =
         ZCB(10)
-        |> Encode.fromPackedFixed32 fid [ 0; -1 ]
+        |> Encode.fromPackedFixed32 fid [ 0u; uint32 -1 ]
+        |> toArray
+        |> should equal [| 0x08uy ||| 2uy; 8uy; 0x00uy;0x00uy;0x00uy;0x00uy; 0xFFuy;0xFFuy;0xFFuy;0xFFuy |]
+
+    [<Fact>]
+    let ``Encode Packed Fixed64`` () =
+        ZCB(18)
+        |> Encode.fromPackedFixed64 fid [ 0UL; uint64 -1 ]
+        |> toArray
+        |> should equal [| 0x08uy ||| 2uy; 16uy; 0x00uy;0x00uy;0x00uy;0x00uy;0x00uy;0x00uy;0x00uy;0x00uy; 0xFFuy;0xFFuy;0xFFuy;0xFFuy;0xFFuy;0xFFuy;0xFFuy;0xFFuy |]
+
+    [<Fact>]
+    let ``Encode Packed SFixed32`` () =
+        ZCB(10)
+        |> Encode.fromPackedSFixed32 fid [ 0; -1 ]
         |> toArray
         |> should equal [| 0x08uy ||| 2uy; 8uy; 0x00uy;0x00uy;0x00uy;0x00uy; 0xFFuy;0xFFuy;0xFFuy;0xFFuy |]
         
 
     [<Fact>]
-    let ``Encode Packed Fixed64`` () =
+    let ``Encode Packed SFixed64`` () =
         ZCB(18)
-        |> Encode.fromPackedFixed64 fid [ 0; -1 ]
+        |> Encode.fromPackedSFixed64 fid [ 0L; -1L ]
         |> toArray
         |> should equal [| 0x08uy ||| 2uy; 16uy; 0x00uy;0x00uy;0x00uy;0x00uy;0x00uy;0x00uy;0x00uy;0x00uy; 0xFFuy;0xFFuy;0xFFuy;0xFFuy;0xFFuy;0xFFuy;0xFFuy;0xFFuy |]
 

--- a/Serialization/Encoding.fs
+++ b/Serialization/Encoding.fs
@@ -161,8 +161,10 @@ module Encode =
     let fromDefaultedSInt64 defV fldNum v = elideDefault defV v <| Pack.toFieldVarint fldNum (zigZag64 v |> uint64)
     let fromDefaultedBool   defV fldNum v = elideDefault defV v <| fromNondefaultedVarint fldNum (boolToInt64 v)
 
-    let inline fromDefaultedFixed32  defV fldNum v = elideDefault defV v <| Pack.toFieldFixed32 fldNum (uint32 v)
-    let inline fromDefaultedFixed64  defV fldNum v = elideDefault defV v <| Pack.toFieldFixed64 fldNum (uint64 v)
+    let fromDefaultedFixed32  defV fldNum v = elideDefault defV v <| Pack.toFieldFixed32 fldNum (uint32 v)
+    let fromDefaultedFixed64  defV fldNum v = elideDefault defV v <| Pack.toFieldFixed64 fldNum (uint64 v)
+    let fromDefaultedSFixed32  defV fldNum (v:int32) = elideDefault defV v <| Pack.toFieldFixed32 fldNum (uint32 v)
+    let fromDefaultedSFixed64  defV fldNum v = elideDefault defV v <| Pack.toFieldFixed64 fldNum (uint64 v)
 
     let fromDefaultedSingle defV fldNum v = elideDefault defV v <| Pack.toFieldSingle fldNum v
     let fromDefaultedDouble defV fldNum v = elideDefault defV v <| Pack.toFieldDouble fldNum v
@@ -176,8 +178,11 @@ module Encode =
     let fromSInt64 fldNum v = fromDefaultedSInt64 0L fldNum v
     let fromBool   fldNum v = fromDefaultedBool false fldNum v
 
-    let inline fromFixed32 fldNum v = fromDefaultedFixed32 0 fldNum v
-    let inline fromFixed64 fldNum v = fromDefaultedFixed64 0 fldNum v
+    let fromFixed32 fldNum (v:uint32) = fromDefaultedFixed32 0u fldNum v
+    let fromFixed64 fldNum (v:uint64) = fromDefaultedFixed64 0UL fldNum v
+    let fromSFixed32 fldNum (v:int32) = fromDefaultedSFixed32 0 fldNum v
+    let fromSFixed64 fldNum (v:int64) = fromDefaultedSFixed64 0L fldNum v
+
 
     let fromSingle fldNum v = fromDefaultedSingle 0.0f fldNum v
     let fromDouble fldNum v = fromDefaultedDouble 0.0 fldNum v
@@ -237,17 +242,29 @@ module Encode =
             (encode >> Pack.toVarint)
             fieldNum xs
 
-    let inline fixedListPackedLen size = (List.length >> ((*) size))
-    let inline fixed32ListPackedLen xs = fixedListPackedLen 4 xs
-    let inline fixed64ListPackedLen xs = fixedListPackedLen 8 xs
+    let inline internal fixedListPackedLen size = (List.length >> ((*) size))
+    let inline internal fixed32ListPackedLen xs = fixedListPackedLen 4 xs
+    let inline internal fixed64ListPackedLen xs = fixedListPackedLen 8 xs
 
-    let inline fromPackedFixed32 fieldNum xs =
+    let fromPackedFixed32 fieldNum (xs:uint32 list) =
         fromPackedHelper
             fixed32ListPackedLen
             (uint32 >> Pack.toFixed32)
             fieldNum xs
 
-    let inline fromPackedFixed64 fieldNum xs =
+    let fromPackedFixed64 fieldNum (xs:uint64 list) =
+        fromPackedHelper
+            fixed64ListPackedLen
+            (uint64 >> Pack.toFixed64)
+            fieldNum xs
+
+    let fromPackedSFixed32 fieldNum (xs:int32 list) =
+        fromPackedHelper
+            fixed32ListPackedLen
+            (uint32 >> Pack.toFixed32)
+            fieldNum xs
+
+    let fromPackedSFixed64 fieldNum (xs:int64 list) =
         fromPackedHelper
             fixed64ListPackedLen
             (uint64 >> Pack.toFixed64)


### PR DESCRIPTION
As mentioned in bug #45, encoding of fixed and sfixed types needs a little love.
Encode.fromFixed32/64 now takes unsigned, add fromSFixed32/64, and add fromPackedSFixed32/64.
Also, updated unit tests.