### PR TITLE
Mutable collections

### DIFF
--- a/TypeProvider/Core/Types.fs
+++ b/TypeProvider/Core/Types.fs
@@ -6,7 +6,7 @@ open System.Collections.Generic
 open Froto.Serialization
 open Froto.Serialization.Encoding
 
-// scalar type aliases based on https://developers.google.com/protocol-buffers/docs/proto3#scalar
+// type aliases based on https://developers.google.com/protocol-buffers/docs/proto3#scalar
 type proto_double = float
 type proto_float = float32
 type proto_int32 = int
@@ -22,8 +22,8 @@ type proto_sfixed64 = int64
 type proto_bool = bool
 type proto_string = string
 type proto_bytes = ArraySegment<byte>
-type proto_map<'Key, 'Value> = IReadOnlyDictionary<'Key, 'Value>
-type proto_concrete_map<'Key, 'Value> = Dictionary<'Key, 'Value>
+type proto_repeated<'T> = ResizeArray<'T>
+type proto_map<'Key, 'Value> = Dictionary<'Key, 'Value>
 
 type Writer<'T> = FieldNum -> ZeroCopyBuffer -> 'T -> unit
 type Reader<'T> = RawField -> 'T

--- a/TypeProvider/Generation/Deserialization.fs
+++ b/TypeProvider/Generation/Deserialization.fs
@@ -37,140 +37,75 @@ let private deserializeField (property: PropertyDescriptor) (rawField: Expr) =
     | Enum -> <@@ Codec.readInt32 %%rawField @@>
     | Class -> Expr.callStaticGeneric [property.UnderlyingType] [rawField ] <@@ Codec.readEmbedded<Dummy> x @@> 
 
+let private samePosition field idx = <@@ (%%field: RawField).FieldNum = idx @@>
+
+/// Adds key-value pair to the property that corresponds the map 
+let private handleMapElement this mapDescriptor field = 
+    let map = Expr.PropertyGet(this, mapDescriptor.Property)
+    let keyReader = primitiveReader mapDescriptor.KeyType
+
+    let readMethod, args =
+        match mapDescriptor.ValueTypeKind with
+        | Primitive -> 
+            <@@ Codec.readMapElement x x x x @@>,
+            [map; keyReader; primitiveReader mapDescriptor.ValueType; field]
+        | Enum -> 
+            <@@ Codec.readMapElement x x x x @@>,
+            [map; keyReader; <@@ Codec.readInt32 @@>; field]
+        | Class -> 
+                <@@ Codec.readMessageMapElement<_, Dummy> x x x @@>,
+                [ Expr.box map; keyReader; field ]
+                
+    Expr.callStaticGeneric
+        (map.Type.GenericTypeArguments |> List.ofArray)
+        args
+        readMethod
+
+let private handleRequired this propertyDescriptor field =
+    let value = deserializeField propertyDescriptor field
+    Expr.PropertySet(this, propertyDescriptor.ProvidedProperty, value)
+
+let private handleOptional this propertyDescriptor field =
+    let value = deserializeField propertyDescriptor field
+    let someValue = Expr.callStaticGeneric [value.Type] [value] <@@ Option.some x @@> 
+    Expr.PropertySet(this, propertyDescriptor.ProvidedProperty, someValue)
+
+let private handleRepeated this propertyDescriptor field =
+    let value = deserializeField propertyDescriptor field
+    let list = Expr.PropertyGet(this, propertyDescriptor.ProvidedProperty)
+    match propertyDescriptor.TypeKind with
+    | Class ->
+        Expr.callStaticGeneric 
+            [propertyDescriptor.UnderlyingType]
+            [Expr.box list; value]
+            <@@ ResizeArray.add x x @@>
+    | _ ->
+        let addMethod = list.Type.GetMethod("Add")
+        Expr.Call(list, addMethod, [value])
+
 let readFrom (typeInfo: TypeDescriptor) this allFields =
 
-    // 1. Declare local vars of type Dictionary<,> for all map fields
-    // 2. Declare ResizeArray local variables for all repeated fields
-    // 3. Read all fields from given buffer
-    // 4. Iterate over fields read: if FieldNum matches field position - 
-    //    set corresponding property or add value to the ResizeArray (for repeated fields)
-    // 5. Convert ResizeArray to lists and set repeated fields
-    // 6. Set properties corresponding to map fields using local Dictionary<,> variables
-
     try
-    
-    // for repeated rules - map from property to variable
-    let resizeArrays =
-        typeInfo.AllProperties
-        |> Seq.filter (fun prop -> prop.Rule = Repeated)
-        |> Seq.map (fun prop -> prop, Var(prop.ProvidedProperty.Name, Expr.makeGenericType [prop.UnderlyingType] typedefof<ResizeArray<_>>))
-        |> dict
-        
-    let dictionaries = 
-        typeInfo.Maps
-        |> Seq.map (fun map -> 
-            map, 
-            Var(map.Property.Name, 
-                Expr.makeGenericType 
-                    (map.Property.PropertyType.GenericTypeArguments |> List.ofArray) 
-                    typedefof<proto_concrete_map<_, _>>))
-        |> dict
+        // handlers for all properties, depending on position
+        let handlers = 
+            typeInfo.AllProperties
+            |> Seq.map (fun prop -> 
+                match prop.Rule with
+                | Required -> prop.Position, handleRequired this prop
+                | Optional -> prop.Position, handleOptional this prop
+                | Repeated -> prop.Position, handleRepeated this prop)
+            |> Seq.append (typeInfo.Maps |> Seq.map(fun map -> map.Position, handleMapElement this map))
+            |> List.ofSeq
 
-    let samePosition field idx = <@@ (%%field: RawField).FieldNum = idx @@>
-
-    /// For required and optional fields - set the property directly;
-    /// for repeated - add to corresponding ResizeArray
-    let handleField (property: PropertyDescriptor) (field: Expr) =
-        let value = deserializeField property field
-        
-        match property.Rule with
-        | Repeated -> 
-            let list = Expr.Var(resizeArrays.[property])
-            match property.TypeKind with
-            | Class ->
-                Expr.callStaticGeneric 
-                    [list.Type.GenericTypeArguments.[0]]
-                    [Expr.box list; value]
-                    <@@ ResizeArray.add x x @@>
-            | _ ->
-                let addMethod = list.Type.GetMethod("Add")
-                Expr.Call(list, addMethod, [value])
-        | Optional ->
-            let someValue = Expr.callStaticGeneric [value.Type] [value] <@@ Option.some x @@> 
-            Expr.PropertySet(this, property.ProvidedProperty, someValue)
-        | Required ->
-            Expr.PropertySet(this, property.ProvidedProperty, value)
-            
-    let handleMap map field = 
-        let dict = Expr.Var(dictionaries.[map])
-        let keyReader = primitiveReader map.KeyType
-
-        let readMethod, args =
-            match map.ValueTypeKind with
-            | Primitive -> 
-                <@@ Codec.readMapElement x x x x @@>,
-                [dict; keyReader; primitiveReader map.ValueType; field]
-            | Enum -> 
-                <@@ Codec.readMapElement x x x x @@>,
-                [dict; keyReader; <@@ Codec.readInt32 @@>; field]
-            | Class -> 
-                    <@@ Codec.readMessageMapElement<_, Dummy> x x x @@>,
-                    [ Expr.box dict; keyReader; field ]
-                    
-        Expr.callStaticGeneric
-            (dict.Type.GenericTypeArguments |> List.ofArray)
-            args
-            readMethod
-
-    /// Converts ResizeArray to immutable list and sets corresponding repeated property
-    let setRepeatedProperty property (resizeArrayVar: Var) =
-        let itemTy = resizeArrayVar.Type.GenericTypeArguments.[0]
-        let list = 
-            match property.TypeKind with
-            | Class ->
-                Expr.callStaticGeneric 
-                    [itemTy] 
-                    [Expr.box <| Expr.Var(resizeArrayVar)]
-                    <@@ ResizeArray.toList x @@> 
-            | _ -> 
-                Expr.callStaticGeneric [itemTy] [Expr.Var(resizeArrayVar)] <@@ List.ofSeq<_> x @@>
-
-        Expr.PropertySet(this, property.ProvidedProperty, list)
-        
-    let setMapProperty map content = 
-        Expr.PropertySet(this, map.Property, Expr.Var(content))
-
-    let fieldLoop = Expr.forLoop <@@ ZeroCopyBuffer.allFields %%allFields @@> (fun field ->
-        let maps = 
-            typeInfo.Maps
-            |> Seq.fold 
-                (fun acc prop ->
+        Expr.forLoop <@@ ZeroCopyBuffer.allFields %%allFields @@> (fun field ->
+            handlers
+            |> List.fold
+                (fun acc (pos, handler) ->
                     Expr.IfThenElse(
-                        samePosition field prop.Position,
-                        handleMap prop field,
-                        acc
-                    ))
-                (Expr.Value(()))
-
-        typeInfo.AllProperties
-        |> Seq.fold
-            (fun acc prop ->
-                Expr.IfThenElse(
-                    samePosition field prop.Position,
-                    handleField prop field,
-                    acc))
-            maps)
-
-    let setRepeatedFields =
-        resizeArrays
-        |> Seq.map (fun pair -> setRepeatedProperty pair.Key pair.Value)
-        |> List.ofSeq
-        
-    let setMapFields = 
-        dictionaries
-        |> Seq.map (fun pair -> setMapProperty pair.Key pair.Value)
-        |> List.ofSeq
-
-    let create ty = Expr.callStaticGeneric [ty] [] <@@ create<_>() @@>
-    
-    let body = fieldLoop :: setRepeatedFields @ setMapFields |> Expr.sequence
-
-    let body = 
-        resizeArrays.Values
-        |> Seq.fold (fun acc var -> Expr.Let(var, create var.Type, acc)) body
-    
-    dictionaries.Values
-    |> Seq.fold (fun acc var -> Expr.Let(var, create var.Type, acc)) body
+                        samePosition field pos,
+                        handler field,
+                        acc))
+                (Expr.Value(())))
 
     with
     | ex ->


### PR DESCRIPTION
Previously, for repeated fields type provider generated writeable property of type `list<'T>`. Similarly, for maps, `IReadOnlyDictionary<'T, 'K>` property was generated.
Now, type provider generates read-only properties, but of mutable collection types: `ResizeArray<T>` and `Dictionary<'T, 'K>`. It might be easier to use and it simplifies type provider code a bit.