### PR TITLE
use Nerdbank.GitVersioning

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ TestResults/
 /.fake
 AssemblyInfo.fs
 docs/type-provider/paket.lock
+.idea/

--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ TestResults/
 AssemblyInfo.fs
 docs/type-provider/paket.lock
 .idea/
+.vs/

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: csharp
+dist: xenial
 mono: none
 dotnet: 2.2.105
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: csharp
 mono: none
-dotnet: 2.1.3
+dotnet: 2.2.3
 script:
   - dotnet restore Froto.sln
   - dotnet build Froto.sln -c Release

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: csharp
 mono: none
-dotnet: 2.2.2
+dotnet: 2.2.105
 script:
   - dotnet restore Froto.sln
   - dotnet build Froto.sln -c Release

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: csharp
 mono: none
-dotnet: 2.2.3
+dotnet: 2.2.2
 script:
   - dotnet restore Froto.sln
   - dotnet build Froto.sln -c Release

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ dist: xenial
 mono: none
 dotnet: 2.2.105
 script:
+  - git fetch --unshallow
   - dotnet restore Froto.sln
   - dotnet build Froto.sln -c Release
   - dotnet test Parser.Test/Froto.Parser.Test.fsproj

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: csharp
 mono: none
 dotnet: 2.1.3
 script:
-  - dotnet restore Froto.unix.sln
-  - dotnet build Froto.unix.sln -c Release
+  - dotnet restore Froto.sln
+  - dotnet build Froto.sln -c Release
   - dotnet test Parser.Test/Froto.Parser.Test.fsproj
   - dotnet test Serialization.Test/Froto.Serialization.Test.fsproj

--- a/Compiler/Froto.Compiler.fsproj
+++ b/Compiler/Froto.Compiler.fsproj
@@ -27,6 +27,6 @@
     <PackageReference Update="FSharp.Core" Version="4.5.2" />
     <PackageReference Include="Argu" Version="4.0.0" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0-beta-63127-02" PrivateAssets="All" />
-    <!-- <PackageReference Include="Nerdbank.GitVersioning" Version="2.3.136" PrivateAssets="All" /> -->
+    <PackageReference Include="Nerdbank.GitVersioning" Version="2.3.138" PrivateAssets="All" />
   </ItemGroup>
 </Project>

--- a/Compiler/Froto.Compiler.fsproj
+++ b/Compiler/Froto.Compiler.fsproj
@@ -26,7 +26,7 @@
     <ProjectReference Include="..\Parser\Froto.Parser.fsproj" />
     <PackageReference Update="FSharp.Core" Version="4.5.2" />
     <PackageReference Include="Argu" Version="4.0.0" />
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0-*" PrivateAssets="All" />
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0-beta-63127-02" PrivateAssets="All" />
     <!-- <PackageReference Include="Nerdbank.GitVersioning" Version="2.3.136" /> -->
   </ItemGroup>
 </Project>

--- a/Compiler/Froto.Compiler.fsproj
+++ b/Compiler/Froto.Compiler.fsproj
@@ -27,5 +27,6 @@
     <PackageReference Update="FSharp.Core" Version="4.5.2" />
     <PackageReference Include="Argu" Version="4.0.0" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0-*" PrivateAssets="All" />
+    <PackageReference Include="Nerdbank.GitVersioning" Version="2.3.136" />
   </ItemGroup>
 </Project>

--- a/Compiler/Froto.Compiler.fsproj
+++ b/Compiler/Froto.Compiler.fsproj
@@ -27,6 +27,6 @@
     <PackageReference Update="FSharp.Core" Version="4.5.2" />
     <PackageReference Include="Argu" Version="4.0.0" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0-beta-63127-02" PrivateAssets="All" />
-    <!-- <PackageReference Include="Nerdbank.GitVersioning" Version="2.3.136" /> -->
+    <!-- <PackageReference Include="Nerdbank.GitVersioning" Version="2.3.136" PrivateAssets="All" /> -->
   </ItemGroup>
 </Project>

--- a/Compiler/Froto.Compiler.fsproj
+++ b/Compiler/Froto.Compiler.fsproj
@@ -27,6 +27,6 @@
     <PackageReference Update="FSharp.Core" Version="4.5.2" />
     <PackageReference Include="Argu" Version="4.0.0" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0-*" PrivateAssets="All" />
-    <PackageReference Include="Nerdbank.GitVersioning" Version="2.3.136" />
+    <!-- <PackageReference Include="Nerdbank.GitVersioning" Version="2.3.136" /> -->
   </ItemGroup>
 </Project>

--- a/Froto.sln
+++ b/Froto.sln
@@ -38,17 +38,15 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "protobuf", "protobuf", "{82
 		test\google\protobuf\descriptor.proto = test\google\protobuf\descriptor.proto
 	EndProjectSection
 EndProject
-Project("{6EC3EE1D-3C4E-46DD-8F32-0CC8E7565705}") = "Froto.Parser", "Parser/Froto.Parser.fsproj", "{1C31DA31-BEC5-4E73-9D83-E36D18847439}"
+Project("{6EC3EE1D-3C4E-46DD-8F32-0CC8E7565705}") = "Froto.Parser", "Parser\Froto.Parser.fsproj", "{1C31DA31-BEC5-4E73-9D83-E36D18847439}"
 EndProject
-Project("{6EC3EE1D-3C4E-46DD-8F32-0CC8E7565705}") = "Froto.Parser.Test", "Parser.Test/Froto.Parser.Test.fsproj", "{18104831-6F33-4F15-AB45-3E8527CC5181}"
+Project("{6EC3EE1D-3C4E-46DD-8F32-0CC8E7565705}") = "Froto.Parser.Test", "Parser.Test\Froto.Parser.Test.fsproj", "{18104831-6F33-4F15-AB45-3E8527CC5181}"
 EndProject
-Project("{6EC3EE1D-3C4E-46DD-8F32-0CC8E7565705}") = "Froto.Serialization", "Serialization/Froto.Serialization.fsproj", "{C37745D0-275D-4DCE-9DDC-C4663A462EDD}"
+Project("{6EC3EE1D-3C4E-46DD-8F32-0CC8E7565705}") = "Froto.Serialization", "Serialization\Froto.Serialization.fsproj", "{C37745D0-275D-4DCE-9DDC-C4663A462EDD}"
 EndProject
-Project("{6EC3EE1D-3C4E-46DD-8F32-0CC8E7565705}") = "Froto.Serialization.Test", "Serialization.Test/Froto.Serialization.Test.fsproj", "{AF2D437D-55A1-4F31-86BD-9B9D7E05CAEA}"
+Project("{6EC3EE1D-3C4E-46DD-8F32-0CC8E7565705}") = "Froto.Serialization.Test", "Serialization.Test\Froto.Serialization.Test.fsproj", "{AF2D437D-55A1-4F31-86BD-9B9D7E05CAEA}"
 EndProject
-Project("{F2A71F9B-5D33-465A-A702-920D77279786}") = "Froto.Compiler", "Compiler/Froto.Compiler.fsproj", "{F5D8D709-919D-4539-8908-91C540C970B3}"
-EndProject
-Project("{6EC3EE1D-3C4E-46DD-8F32-0CC8E7565705}") = "Froto.TypeProvider", "TypeProvider/Froto.TypeProvider.fsproj", "{837AA4FC-E2DD-48A1-A793-50DC4404EE57}"
+Project("{6EC3EE1D-3C4E-46DD-8F32-0CC8E7565705}") = "Froto.Compiler", "Compiler\Froto.Compiler.fsproj", "{F5D8D709-919D-4539-8908-91C540C970B3}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -76,10 +74,6 @@ Global
 		{F5D8D709-919D-4539-8908-91C540C970B3}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{F5D8D709-919D-4539-8908-91C540C970B3}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{F5D8D709-919D-4539-8908-91C540C970B3}.Release|Any CPU.Build.0 = Release|Any CPU
-		{837AA4FC-E2DD-48A1-A793-50DC4404EE57}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{837AA4FC-E2DD-48A1-A793-50DC4404EE57}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{837AA4FC-E2DD-48A1-A793-50DC4404EE57}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{837AA4FC-E2DD-48A1-A793-50DC4404EE57}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/Parser.Test/Froto.Parser.Test.fsproj
+++ b/Parser.Test/Froto.Parser.Test.fsproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="TestParser.fs" />

--- a/Parser.Test/Froto.Parser.Test.fsproj
+++ b/Parser.Test/Froto.Parser.Test.fsproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFramework>netcoreapp2.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="TestParser.fs" />

--- a/Parser.Test/TestParser.fs
+++ b/Parser.Test/TestParser.fs
@@ -1060,6 +1060,7 @@ module RegressionTests =
 
     [<Fact>]
     let ``proto3 oneof type doesn't parse (#88)`` () =
+        System.Diagnostics.Debugger.Break()
         Parse.fromStringWithParser pProto """
             syntax = "proto3";
 
@@ -1082,47 +1083,4 @@ module RegressionTests =
                             ])
 
                     ])
-            ])
-
-    [<Fact>]
-    let ``proto3 message with enum type doesn't parse (#93)`` () =
-        Parse.fromStringWithParser pProto """
-            syntax = "proto3";
-
-            message SearchRequest {
-              string query = 1;
-              int32 page_number = 2;
-              int32 result_per_page = 3;
-              enum Corpus {
-                UNIVERSAL = 0;
-                WEB = 1;
-                IMAGES = 2;
-                LOCAL = 3;
-                NEWS = 4;
-                PRODUCTS = 5;
-                VIDEO = 6;
-              }
-              Corpus corpus = 4;
-            }
-        """
-        |> should equal (
-            [
-                TSyntax TProto3
-                TMessage ("SearchRequest",
-                     [
-                          TField ("query",TOptional,TString,1u,[])
-                          TField ("page_number",TOptional,TInt32,2u,[])
-                          TField ("result_per_page",TOptional,TInt32,3u,[])
-                          TMessageEnum("Corpus",
-                                [
-                                     TEnumField ("UNIVERSAL",0,[])
-                                     TEnumField ("WEB",1,[])
-                                     TEnumField ("IMAGES",2,[])
-                                     TEnumField ("LOCAL",3,[])
-                                     TEnumField ("NEWS",4,[])
-                                     TEnumField ("PRODUCTS",5,[])
-                                     TEnumField ("VIDEO",6,[])
-                                ])
-                          TField ("corpus", TOptional,TIdent "Corpus",4u,[])
-                     ])
             ])

--- a/Parser.Test/TestParser.fs
+++ b/Parser.Test/TestParser.fs
@@ -1060,7 +1060,6 @@ module RegressionTests =
 
     [<Fact>]
     let ``proto3 oneof type doesn't parse (#88)`` () =
-        System.Diagnostics.Debugger.Break()
         Parse.fromStringWithParser pProto """
             syntax = "proto3";
 

--- a/Parser/Froto.Parser.fsproj
+++ b/Parser/Froto.Parser.fsproj
@@ -21,5 +21,6 @@
     <PackageReference Update="FSharp.Core" Version="4.5.2" />
     <PackageReference Include="FParsec" Version="1.0.3" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0-*" PrivateAssets="All" />
+    <PackageReference Include="Nerdbank.GitVersioning" Version="2.3.136" />
   </ItemGroup>
 </Project>

--- a/Parser/Froto.Parser.fsproj
+++ b/Parser/Froto.Parser.fsproj
@@ -20,7 +20,7 @@
   <ItemGroup>
     <PackageReference Update="FSharp.Core" Version="4.5.2" />
     <PackageReference Include="FParsec" Version="1.0.3" />
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0-*" PrivateAssets="All" />
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0-beta-63127-02" PrivateAssets="All" />
     <PackageReference Include="Nerdbank.GitVersioning" Version="2.3.136" />
   </ItemGroup>
 </Project>

--- a/Parser/Froto.Parser.fsproj
+++ b/Parser/Froto.Parser.fsproj
@@ -20,7 +20,7 @@
   <ItemGroup>
     <PackageReference Update="FSharp.Core" Version="4.5.2" />
     <PackageReference Include="FParsec" Version="1.0.3" />
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0-*" PrivateAssets="All" />
+    <!-- <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0-*" PrivateAssets="All" /> -->
     <PackageReference Include="Nerdbank.GitVersioning" Version="2.3.136" />
   </ItemGroup>
 </Project>

--- a/Parser/Froto.Parser.fsproj
+++ b/Parser/Froto.Parser.fsproj
@@ -21,6 +21,6 @@
     <PackageReference Update="FSharp.Core" Version="4.5.2" />
     <PackageReference Include="FParsec" Version="1.0.3" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0-beta-63127-02" PrivateAssets="All" />
-    <PackageReference Include="Nerdbank.GitVersioning" Version="2.3.136" />
+    <PackageReference Include="Nerdbank.GitVersioning" Version="2.3.136" PrivateAssets="All" />
   </ItemGroup>
 </Project>

--- a/Parser/Froto.Parser.fsproj
+++ b/Parser/Froto.Parser.fsproj
@@ -21,6 +21,6 @@
     <PackageReference Update="FSharp.Core" Version="4.5.2" />
     <PackageReference Include="FParsec" Version="1.0.3" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0-beta-63127-02" PrivateAssets="All" />
-    <PackageReference Include="Nerdbank.GitVersioning" Version="2.3.136" PrivateAssets="All" />
+    <PackageReference Include="Nerdbank.GitVersioning" Version="2.3.138" PrivateAssets="All" />
   </ItemGroup>
 </Project>

--- a/Parser/Froto.Parser.fsproj
+++ b/Parser/Froto.Parser.fsproj
@@ -20,7 +20,7 @@
   <ItemGroup>
     <PackageReference Update="FSharp.Core" Version="4.5.2" />
     <PackageReference Include="FParsec" Version="1.0.3" />
-    <!-- <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0-*" PrivateAssets="All" /> -->
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0-*" PrivateAssets="All" />
     <PackageReference Include="Nerdbank.GitVersioning" Version="2.3.136" />
   </ItemGroup>
 </Project>

--- a/Parser/Parser.fs
+++ b/Parser/Parser.fs
@@ -482,6 +482,7 @@ module Parse =
             choice [
                 (isProto2 >>. pGroup) // must be parsed first to avoid confusion
                 pOneOf                // must be parsed before pField, so 'oneof' isn't considered a type in Proto3
+                pField
                 pMessageEnum
                 pMessageMessage
                 (isProto2 >>. pMessageExtend)
@@ -489,7 +490,6 @@ module Parse =
                 pMessageOption
                 pMap
                 pReserved
-                pField
                 ]
 
         /// Parse message option: "option" (ident | "(" fullIdent ")" { "." ident }

--- a/Serialization.Test/TestSerialization.fs
+++ b/Serialization.Test/TestSerialization.fs
@@ -206,7 +206,7 @@ module RecordSerialization =
                 ]
                 |> Map.ofList
     
-            static member DecodeFixup m =
+            static member DecodeFixup m: Proto3Message =
                 { m with _unknownFields = List.rev m._unknownFields }
 
             static member UnknownFields m =

--- a/Serialization/Froto.Serialization.fsproj
+++ b/Serialization/Froto.Serialization.fsproj
@@ -24,6 +24,6 @@
   <ItemGroup>
     <PackageReference Update="FSharp.Core" Version="4.5.2" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0-beta-63127-02" PrivateAssets="All" />
-    <PackageReference Include="Nerdbank.GitVersioning" Version="2.3.136" />
+    <PackageReference Include="Nerdbank.GitVersioning" Version="2.3.136" PrivateAssets="All" />
   </ItemGroup>
 </Project>

--- a/Serialization/Froto.Serialization.fsproj
+++ b/Serialization/Froto.Serialization.fsproj
@@ -24,6 +24,6 @@
   <ItemGroup>
     <PackageReference Update="FSharp.Core" Version="4.5.2" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0-beta-63127-02" PrivateAssets="All" />
-    <PackageReference Include="Nerdbank.GitVersioning" Version="2.3.136" PrivateAssets="All" />
+    <PackageReference Include="Nerdbank.GitVersioning" Version="2.3.138" PrivateAssets="All" />
   </ItemGroup>
 </Project>

--- a/Serialization/Froto.Serialization.fsproj
+++ b/Serialization/Froto.Serialization.fsproj
@@ -24,5 +24,6 @@
   <ItemGroup>
     <PackageReference Update="FSharp.Core" Version="4.5.2" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0-*" PrivateAssets="All" />
+    <PackageReference Include="Nerdbank.GitVersioning" Version="2.3.136" />
   </ItemGroup>
 </Project>

--- a/Serialization/Froto.Serialization.fsproj
+++ b/Serialization/Froto.Serialization.fsproj
@@ -23,7 +23,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Update="FSharp.Core" Version="4.5.2" />
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0-*" PrivateAssets="All" />
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0-beta-63127-02" PrivateAssets="All" />
     <PackageReference Include="Nerdbank.GitVersioning" Version="2.3.136" />
   </ItemGroup>
 </Project>

--- a/TypeProvider/Froto.TypeProvider.fsproj
+++ b/TypeProvider/Froto.TypeProvider.fsproj
@@ -47,6 +47,6 @@
     <PackageReference Update="FSharp.Core" Version="4.5.2" />
     <Reference Include="System.Runtime.Caching" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0-beta-63127-02" PrivateAssets="All" />
-    <PackageReference Include="Nerdbank.GitVersioning" Version="2.3.136" />
+    <PackageReference Include="Nerdbank.GitVersioning" Version="2.3.136" PrivateAssets="All" />
   </ItemGroup>
 </Project>

--- a/TypeProvider/Froto.TypeProvider.fsproj
+++ b/TypeProvider/Froto.TypeProvider.fsproj
@@ -46,7 +46,7 @@
   <ItemGroup>
     <PackageReference Update="FSharp.Core" Version="4.5.2" />
     <Reference Include="System.Runtime.Caching" />
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0-*" PrivateAssets="All" />
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0-beta-63127-02" PrivateAssets="All" />
     <PackageReference Include="Nerdbank.GitVersioning" Version="2.3.136" />
   </ItemGroup>
 </Project>

--- a/TypeProvider/Froto.TypeProvider.fsproj
+++ b/TypeProvider/Froto.TypeProvider.fsproj
@@ -47,5 +47,6 @@
     <PackageReference Update="FSharp.Core" Version="4.5.2" />
     <Reference Include="System.Runtime.Caching" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0-*" PrivateAssets="All" />
+    <PackageReference Include="Nerdbank.GitVersioning" Version="2.3.136" />
   </ItemGroup>
 </Project>

--- a/TypeProvider/Froto.TypeProvider.fsproj
+++ b/TypeProvider/Froto.TypeProvider.fsproj
@@ -47,6 +47,6 @@
     <PackageReference Update="FSharp.Core" Version="4.5.2" />
     <Reference Include="System.Runtime.Caching" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0-beta-63127-02" PrivateAssets="All" />
-    <PackageReference Include="Nerdbank.GitVersioning" Version="2.3.136" PrivateAssets="All" />
+    <PackageReference Include="Nerdbank.GitVersioning" Version="2.3.138" PrivateAssets="All" />
   </ItemGroup>
 </Project>

--- a/build.ps1
+++ b/build.ps1
@@ -1,22 +1,10 @@
-$version = '0.7.0' # the version under development, update after a release
-$versionSuffix = '-build.0' # manually incremented for local builds
- 
-function isVersionTag($tag){
-    $v = New-Object Version
-    [Version]::TryParse($tag, [ref]$v)
-}
-
-if ($env:appveyor){
-    $versionSuffix = '-build.' + $env:appveyor_build_number
-    if ($env:appveyor_repo_tag -eq 'true' -and (isVersionTag($env:appveyor_repo_tag_name))){
-        $version = $env:appveyor_repo_tag_name
-        $versionSuffix = ''
-    }
-    Update-AppveyorBuild -Version "$version$versionSuffix"
-}
-
-dotnet build -c Release Froto.sln /p:Version=$version$versionSuffix
+dotnet build -c Release Froto.sln
+if ($lastexitcode -ne 0){ exit $lastexitcode }
 dotnet test --no-build -c Release Parser.Test\Froto.Parser.Test.fsproj
+if ($lastexitcode -ne 0){ exit $lastexitcode }
 dotnet test --no-build -c Release Serialization.Test\Froto.Serialization.Test.fsproj
-dotnet pack --no-build -c Release Parser\Froto.Parser.fsproj /p:Version=$version$versionSuffix -o $psscriptroot/bin
-dotnet pack --no-build -c Release Serialization\Froto.Serialization.fsproj /p:Version=$version$versionSuffix -o $psscriptroot/bin
+if ($lastexitcode -ne 0){ exit $lastexitcode }
+dotnet pack --no-build -c Release Parser\Froto.Parser.fsproj -o $psscriptroot/bin
+if ($lastexitcode -ne 0){ exit $lastexitcode }
+dotnet pack --no-build -c Release Serialization\Froto.Serialization.fsproj -o $psscriptroot/bin
+if ($lastexitcode -ne 0){ exit $lastexitcode }

--- a/version.json
+++ b/version.json
@@ -1,0 +1,17 @@
+{
+    "$schema": "https://raw.githubusercontent.com/AArnott/Nerdbank.GitVersioning/master/src/NerdBank.GitVersioning/version.schema.json",
+    "version": "0.6",
+    "nugetPackageVersion": {
+        "semVer": 2
+    },
+    "gitCommitIdShortAutoMinimum": 7,
+    "publicReleaseRefSpec": [
+        "^refs/heads/master$",
+        "^refs/heads/\\d+\\.\\d+$"
+    ],
+    "cloudBuild": {
+        "buildNumber": {
+            "enabled": true
+        }
+    }
+}


### PR DESCRIPTION
This revising the build system to use versioning from https://github.com/AArnott/Nerdbank.GitVersioning. It is one step closer to being fully deterministic so that you can build the same package locally, on AppVeyor, on Travis CI, on Azure Pipelines, or any other CI and get the same bytes. For convenience, the prelease versions are simply the git commit short and match git rev-parse --short HEAD as well as what GitHub shows.

@7sharp9, you should be able to run./build.ps1 and get a nupkg to try out elsewhere.