### PR TITLE
use Azure Pipelines for Windows builds

### DIFF
--- a/NuGet.Config
+++ b/NuGet.Config
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <packageSources>
+    <clear />
+    <add key="nuget.org" value="https://api.nuget.org/v3/index.json" protocolVersion="3" />
+  </packageSources>
+</configuration>

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,8 +1,0 @@
-image: Visual Studio 2017
-build_script:
-  - ps: |
-      .\build.ps1
-      if ($lastexitcode -ne 0){ exit $lastexitcode }
-test: off
-artifacts:
-  - path: bin\*.nupkg

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -6,7 +6,9 @@ jobs:
   # container: 'mcr.microsoft.com/dotnet/core/sdk:2.2.105-nanoserver-1803'
   steps:
   - script: |
-      dotnet --info
+      dotnet --version
+      .\build.ps1
+      if ($lastexitcode -ne 0){ exit $lastexitcode }
 
 - job: Linux
   pool:
@@ -15,7 +17,6 @@ jobs:
   steps:
   - script: |
       set -e
-      dotnet --info
       ./build.sh
       ./build-checksum.sh
   - task: CopyFiles@2

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -5,7 +5,7 @@ jobs:
     vmImage: win1803
   # container: 'mcr.microsoft.com/dotnet/core/sdk:2.2.105-nanoserver-1803'
   steps:
-  - script: |
+  - powershell: |
       dotnet --version
       .\build.ps1
       if ($lastexitcode -ne 0){ exit $lastexitcode }

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -3,7 +3,7 @@ jobs:
 - job: Windows
   pool:
     vmImage: win1803
-  container: mcr.microsoft.com/dotnet/core/sdk:2.2.105
+  container: 'mcr.microsoft.com/dotnet/core/sdk:2.2.105-nanoserver-1803'
   steps:
   - script: |
       dotnet --info

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,16 +1,29 @@
-pool:
-  vmImage: Ubuntu-16.04
-steps:
-- script: |
-    set -e
-    ./build.sh
-    ./build-checksum.sh
-- task: CopyFiles@2
-  inputs:
-    contents: bin/*.nupkg
-    flattenFolders: true
-    targetFolder: $(Build.ArtifactStagingDirectory)
-- task: PublishBuildArtifacts@1
-  inputs:
-    pathtoPublish: $(Build.ArtifactStagingDirectory)
-    artifactName: nuget
+jobs:
+
+- job: Windows
+  pool:
+    vmImage: win1803
+  container: mcr.microsoft.com/dotnet/core/sdk:2.2.105
+  steps:
+  - script: |
+      dotnet --info
+
+- job: Linux
+  pool:
+    vmImage: Ubuntu-16.04
+  container: mcr.microsoft.com/dotnet/core/sdk:2.2.105
+  steps:
+  - script: |
+      set -e
+      dotnet --info
+      ./build.sh
+      ./build-checksum.sh
+  - task: CopyFiles@2
+    inputs:
+      contents: bin/*.nupkg
+      flattenFolders: true
+      targetFolder: $(Build.ArtifactStagingDirectory)
+  - task: PublishBuildArtifacts@1
+    inputs:
+      pathtoPublish: $(Build.ArtifactStagingDirectory)
+      artifactName: nuget

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -3,7 +3,7 @@ jobs:
 - job: Windows
   pool:
     vmImage: win1803
-  container: 'mcr.microsoft.com/dotnet/core/sdk:2.2.105-nanoserver-1803'
+  # container: 'mcr.microsoft.com/dotnet/core/sdk:2.2.105-nanoserver-1803'
   steps:
   - script: |
       dotnet --info


### PR DESCRIPTION
AppVeyor is still on dotnet sdk 2.2.103 which has a bug. Eventually, I want to get to only container builds. At a minimum, I want to be able to specify the dotnet sdk version.