### PR TITLE
Process import statements

### DIFF
--- a/Parser.Test/TestParser.fs
+++ b/Parser.Test/TestParser.fs
@@ -1136,18 +1136,18 @@ module Import =
 
     [<Fact>]
     let ``Resolve Import Statement`` () =
-        let src = """
-            syntax = "proto2";
-
-            import "import.proto";
-
-            message Test {
-                optional MyEnum a = 1;
-                }
-            """
-
         let fetch name =
             let aux = function
+                | "test.proto" ->
+                        """
+                        syntax = "proto2";
+
+                        import "import.proto";
+
+                        message Test {
+                            optional MyEnum a = 1;
+                            }
+                        """
                 | "import.proto" ->
                         """
                         enum MyEnum {
@@ -1162,9 +1162,8 @@ module Import =
             (name, Parse.fromString s)
 
         let ast =
-            src
-            |> Parse.fromString
-            |> fun ast -> ("test.proto", ast)
+            fetch "test.proto"
+            |> parse
             |> Parse.resolveImports fetch parse
 
         ast |> should equal (
@@ -1186,18 +1185,18 @@ module Import =
 
     [<Fact>]
     let ``Resolve Recursive Import Statements`` () =
-        let src = """
-            syntax = "proto2";
-
-            import "import.proto";
-
-            message Test {
-                optional MyEnum a = 1;
-                }
-            """
-
         let fetch name =
             let aux = function
+                | "test.proto" ->
+                        """
+                        syntax = "proto2";
+
+                        import "import.proto";
+
+                        message Test {
+                            optional MyEnum a = 1;
+                            }
+                        """
                 | "import.proto" ->
                         """
                         import "inner.proto";
@@ -1216,9 +1215,8 @@ module Import =
             (name, Parse.fromString s)
 
         let ast =
-            src
-            |> Parse.fromString
-            |> fun ast -> ("test.proto", ast)
+            fetch "test.proto"
+            |> parse
             |> Parse.resolveImports fetch parse
 
         ast |> should equal (
@@ -1241,12 +1239,12 @@ module Import =
 
     [<Fact>]
     let ``Missing import throws`` () =
-        let src = """
-            import "missing.proto";
-            """
-
         let fetch name =
             let aux = function
+                | "test.proto" ->
+                    """
+                    import "missing.proto";
+                    """
                 | s -> raise <| System.IO.FileNotFoundException(s)
             (name, aux name)
 
@@ -1254,27 +1252,26 @@ module Import =
             (name, Parse.fromString s)
 
         fun () ->
-            src
-            |> Parse.fromString
-            |> fun ast -> ("test.proto", ast)
+            fetch "test.proto"
+            |> parse
             |> Parse.resolveImports fetch parse
             |> ignore
         |> should throw typeof<System.IO.FileNotFoundException>
 
     [<Fact>]
     let ``Resolve Public Import Statement`` () =
-        let src = """
-            syntax = "proto2";
-
-            import public "import.proto";
-
-            message Test {
-                optional MyEnum a = 1;
-                }
-            """
-
         let fetch name =
             let aux = function
+                | "test.proto" ->
+                        """
+                        syntax = "proto2";
+
+                        import public "import.proto";
+
+                        message Test {
+                            optional MyEnum a = 1;
+                            }
+                        """
                 | "import.proto" ->
                         """
                         enum MyEnum {
@@ -1289,9 +1286,8 @@ module Import =
             (name, Parse.fromString s)
 
         let ast =
-            src
-            |> Parse.fromString
-            |> fun ast -> ("test.proto", ast)
+            fetch "test.proto"
+            |> parse
             |> Parse.resolveImports fetch parse
 
         ast |> should equal (
@@ -1311,18 +1307,18 @@ module Import =
 
     [<Fact>]
     let ``Resolve recursive Public Import Statement`` () =
-        let src = """
-            syntax = "proto2";
-
-            import public "import.proto";
-
-            message Test {
-                optional MyEnum a = 1;
-                }
-            """
-
         let fetch name =
             let aux = function
+                | "test.proto" ->
+                        """
+                        syntax = "proto2";
+
+                        import public "import.proto";
+
+                        message Test {
+                            optional MyEnum a = 1;
+                            }
+                        """
                 | "import.proto" ->
                         """
                         import public "inner.proto";
@@ -1341,9 +1337,8 @@ module Import =
             (name, Parse.fromString s)
 
         let ast =
-            src
-            |> Parse.fromString
-            |> fun ast -> ("test.proto", ast)
+            fetch "test.proto"
+            |> parse
             |> Parse.resolveImports fetch parse
 
         ast |> should equal (
@@ -1363,12 +1358,12 @@ module Import =
 
     [<Fact>]
     let ``Missing public import throws`` () =
-        let src = """
-            import "missing.proto";
-            """
-
         let fetch name =
             let aux = function
+                | "test.proto" ->
+                    """
+                    import "missing.proto";
+                    """
                 | s -> raise <| System.IO.FileNotFoundException(s)
             (name, aux name)
 
@@ -1376,9 +1371,8 @@ module Import =
             (name, Parse.fromString s)
 
         fun () ->
-            src
-            |> Parse.fromString
-            |> fun ast -> ("test.proto", ast)
+            fetch "test.proto"
+            |> parse
             |> Parse.resolveImports fetch parse
             |> ignore
         |> should throw typeof<System.IO.FileNotFoundException>
@@ -1386,19 +1380,19 @@ module Import =
 
     [<Fact>]
     let ``Resolve Weak Import Statement and ignore missing weak import`` () =
-        let src = """
-            syntax = "proto2";
-
-            import weak "import.proto";
-            import weak "missing.proto";
-
-            message Test {
-                optional MyEnum a = 1;
-                }
-            """
-
         let fetch name =
             let aux = function
+                | "test.proto" ->
+                        """
+                        syntax = "proto2";
+
+                        import weak "import.proto";
+                        import weak "missing.proto";
+
+                        message Test {
+                            optional MyEnum a = 1;
+                            }
+                        """
                 | "import.proto" ->
                         """
                         enum MyEnum {
@@ -1413,9 +1407,8 @@ module Import =
             (name, Parse.fromString s)
 
         let ast =
-            src
-            |> Parse.fromString
-            |> fun ast -> ("test.proto", ast)
+            fetch "test.proto"
+            |> parse
             |> Parse.resolveImports fetch parse
 
         ast |> should equal (

--- a/Parser.Test/TestParser.fs
+++ b/Parser.Test/TestParser.fs
@@ -1136,9 +1136,9 @@ module Import =
 
     [<Fact>]
     let ``Resolve Import Statement`` () =
-        let fetch name =
-            let aux = function
-                | "test.proto" ->
+        let files =
+            [
+                "test.proto",
                         """
                         syntax = "proto2";
 
@@ -1148,24 +1148,18 @@ module Import =
                             optional MyEnum a = 1;
                             }
                         """
-                | "import.proto" ->
+
+                "import.proto",
                         """
                         enum MyEnum {
                             DEFAULT = 0;
                             ONE = 1;
                             }
                         """
-                | s -> raise <| System.IO.FileNotFoundException(s)
-            (name, aux name)
-
-        let parse (name, s) =
-            (name, Parse.fromString s)
-
-        let ast =
-            fetch "test.proto"
-            |> parse
-            |> Parse.resolveImports fetch parse
-
+            ] |> Map.ofList
+        
+        let ast = files |> Parse.loadFromString "test.proto"
+        
         ast |> should equal (
             [ ("test.proto", [
                 TSyntax TProto2
@@ -1185,9 +1179,9 @@ module Import =
 
     [<Fact>]
     let ``Resolve Recursive Import Statements`` () =
-        let fetch name =
-            let aux = function
-                | "test.proto" ->
+        let files =
+            [
+                "test.proto",
                         """
                         syntax = "proto2";
 
@@ -1197,27 +1191,20 @@ module Import =
                             optional MyEnum a = 1;
                             }
                         """
-                | "import.proto" ->
+                "import.proto",
                         """
                         import "inner.proto";
                         """
-                | "inner.proto" ->
+                "inner.proto",
                         """
                         enum MyEnum {
                             DEFAULT = 0;
                             ONE = 1;
                             }
                         """
-                | s -> raise <| System.IO.FileNotFoundException(s)
-            (name, aux name)
+            ] |> Map.ofList
 
-        let parse (name, s) =
-            (name, Parse.fromString s)
-
-        let ast =
-            fetch "test.proto"
-            |> parse
-            |> Parse.resolveImports fetch parse
+        let ast = files |> Parse.loadFromString "test.proto"
 
         ast |> should equal (
             [ ("test.proto", [
@@ -1239,56 +1226,45 @@ module Import =
 
     [<Fact>]
     let ``Missing import throws`` () =
-        let fetch name =
-            let aux = function
-                | "test.proto" ->
+
+        let files =
+            [
+                "test.proto",
                     """
                     import public "missing.proto";
                     """
-                | s -> raise <| System.IO.FileNotFoundException(s)
-            (name, aux name)
-
-        let parse (name, s) =
-            (name, Parse.fromString s)
+            ] |> Map.ofList
 
         fun () ->
-            fetch "test.proto"
-            |> parse
-            |> Parse.resolveImports fetch parse
+            files
+            |> Parse.loadFromString "test.proto"
             |> ignore
         |> should throw typeof<System.IO.FileNotFoundException>
 
     [<Fact>]
     let ``Resolve Public Import Statement`` () =
-        let fetch name =
-            let aux = function
-                | "test.proto" ->
-                        """
-                        syntax = "proto2";
+        let files =
+            [
+                "test.proto",
+                    """
+                    syntax = "proto2";
 
-                        import public "import.proto";
+                    import public "import.proto";
 
-                        message Test {
-                            optional MyEnum a = 1;
-                            }
-                        """
-                | "import.proto" ->
-                        """
-                        enum MyEnum {
-                            DEFAULT = 0;
-                            ONE = 1;
-                            }
-                        """
-                | s -> raise <| System.IO.FileNotFoundException(s)
-            (name, aux name)
+                    message Test {
+                        optional MyEnum a = 1;
+                        }
+                    """
+                "import.proto",
+                    """
+                    enum MyEnum {
+                        DEFAULT = 0;
+                        ONE = 1;
+                        }
+                    """
+            ] |> Map.ofList
 
-        let parse (name, s) =
-            (name, Parse.fromString s)
-
-        let ast =
-            fetch "test.proto"
-            |> parse
-            |> Parse.resolveImports fetch parse
+        let ast = files |> Parse.loadFromString "test.proto"
 
         ast |> should equal (
             [ ("test.proto", [
@@ -1307,39 +1283,32 @@ module Import =
 
     [<Fact>]
     let ``Resolve recursive Public Import Statement`` () =
-        let fetch name =
-            let aux = function
-                | "test.proto" ->
-                        """
-                        syntax = "proto2";
+        let files =
+            [
+                "test.proto",
+                    """
+                    syntax = "proto2";
 
-                        import public "import.proto";
+                    import public "import.proto";
 
-                        message Test {
-                            optional MyEnum a = 1;
-                            }
+                    message Test {
+                        optional MyEnum a = 1;
+                        }
+                    """
+                "import.proto",
+                    """
+                    import public "inner.proto";
+                    """
+                "inner.proto",
+                    """
+                    enum MyEnum {
+                        DEFAULT = 0;
+                        ONE = 1;
+                        }
                         """
-                | "import.proto" ->
-                        """
-                        import public "inner.proto";
-                        """
-                | "inner.proto" ->
-                        """
-                        enum MyEnum {
-                            DEFAULT = 0;
-                            ONE = 1;
-                            }
-                        """
-                | s -> raise <| System.IO.FileNotFoundException(s)
-            (name, aux name)
+            ] |> Map.ofList
 
-        let parse (name, s) =
-            (name, Parse.fromString s)
-
-        let ast =
-            fetch "test.proto"
-            |> parse
-            |> Parse.resolveImports fetch parse
+        let ast = files |> Parse.loadFromString "test.proto"
 
         ast |> should equal (
             [ ("test.proto", [
@@ -1358,58 +1327,46 @@ module Import =
 
     [<Fact>]
     let ``Missing public import throws`` () =
-        let fetch name =
-            let aux = function
-                | "test.proto" ->
+        let files =
+            [
+                "test.proto",
                     """
                     import "missing.proto";
                     """
-                | s -> raise <| System.IO.FileNotFoundException(s)
-            (name, aux name)
-
-        let parse (name, s) =
-            (name, Parse.fromString s)
+            ] |> Map.ofList
 
         fun () ->
-            fetch "test.proto"
-            |> parse
-            |> Parse.resolveImports fetch parse
+            files
+            |> Parse.loadFromString "test.proto"
             |> ignore
         |> should throw typeof<System.IO.FileNotFoundException>
 
 
     [<Fact>]
     let ``Resolve Weak Import Statement and ignore missing weak import`` () =
-        let fetch name =
-            let aux = function
-                | "test.proto" ->
-                        """
-                        syntax = "proto2";
+        let files =
+            [
+                "test.proto",
+                    """
+                    syntax = "proto2";
 
-                        import weak "import.proto";
-                        import weak "missing.proto";
+                    import weak "import.proto";
+                    import weak "missing.proto";
 
-                        message Test {
-                            optional MyEnum a = 1;
-                            }
-                        """
-                | "import.proto" ->
-                        """
-                        enum MyEnum {
-                            DEFAULT = 0;
-                            ONE = 1;
-                            }
-                        """
-                | s -> raise <| System.IO.FileNotFoundException(s)
-            (name, aux name)
+                    message Test {
+                        optional MyEnum a = 1;
+                        }
+                    """
+                "import.proto",
+                    """
+                    enum MyEnum {
+                        DEFAULT = 0;
+                        ONE = 1;
+                        }
+                    """
+            ] |> Map.ofList
 
-        let parse (name, s) =
-            (name, Parse.fromString s)
-
-        let ast =
-            fetch "test.proto"
-            |> parse
-            |> Parse.resolveImports fetch parse
+        let ast = files |> Parse.loadFromString "test.proto"
 
         ast |> should equal (
             [ ("test.proto", [

--- a/Parser.Test/TestParser.fs
+++ b/Parser.Test/TestParser.fs
@@ -11,6 +11,31 @@ open Froto.Parser
 open Froto.Parser.Ast
 open Froto.Parser.Parse.Parsers
 
+module TestHelpers =
+    open System.IO
+
+    // Detect Mono runtime
+    let isMono = System.Type.GetType "Mono.Runtime" |> isNull |> not
+
+    /// Path of the test directory
+    let testPath =
+        let solutionPath =
+            if isMono then
+                "../../../"
+            else
+                let codeBase = Reflection.Assembly.GetExecutingAssembly().CodeBase
+                let codeBase' = Uri.EscapeUriString codeBase 
+                let codeBase'' = codeBase'.Replace("#", "%23") // handle paths like ../F#/..
+                let uri = Uri codeBase''
+                let assemblyPath = DirectoryInfo uri.LocalPath
+                (assemblyPath.Parent.Parent.Parent.Parent.Parent).FullName
+        Path.Combine(solutionPath, "test")
+
+    /// gets the path for a test file based on the relative path from the executing assembly
+    let getTestFilePath file =
+        Path.Combine(testPath, file)
+
+
 [<Xunit.Trait("Kind", "Unit")>]
 module Identifiers =
     [<Fact>]
@@ -854,21 +879,9 @@ module Proto =
         )
 
 
-    open System.IO
-
-    /// gets the path for a test file based on the relative path from the executing assembly
-    let getTestFile file =
-         let codeBase = Reflection.Assembly.GetExecutingAssembly().CodeBase
-         let codeBase' = Uri.EscapeUriString codeBase 
-         let codeBase'' = codeBase'.Replace("#", "%23") // handle paths like ../F#/..
-         let uri = Uri codeBase''
-         let assemblyPath = DirectoryInfo uri.LocalPath
-         let solutionPath = (assemblyPath.Parent.Parent.Parent.Parent.Parent).FullName
-         Path.Combine(solutionPath, Path.Combine("test",file))
-
     [<Fact>]
     let ``Parse Google protobuf 'descriptor.proto' without error`` () =
-        Parse.fromFile <| getTestFile "google/protobuf/descriptor.proto"
+        Parse.fromFile <| TestHelpers.getTestFilePath "google/protobuf/descriptor.proto"
         |> ignore
 
 [<Xunit.Trait("Kind", "Unit")>]
@@ -1132,7 +1145,6 @@ module RegressionTests =
                         TField("corpus", TOptional, TIdent("Corpus"), 4u, [])
                     ])
             ])
-module Import =
 module StringImport =
 
     [<Fact>]
@@ -1393,24 +1405,11 @@ module FileImport =
     open System
     open System.IO
 
-    let isMono = System.Type.GetType "Mono.Runtime" |> isNull |> not
-
-    /// gets the path for a test file based on the relative path from the executing assembly
-    let testDir =
-        let solutionPath =
-            if isMono then
-                "../../../"
-            else
-                let codeBase = Reflection.Assembly.GetExecutingAssembly().CodeBase
-                let assemblyPath = DirectoryInfo (Uri codeBase).LocalPath
-                (assemblyPath.Parent.Parent.Parent.Parent).FullName
-        Path.Combine(solutionPath, "test")
-
     [<Fact>]
     let ``Resolve File Import`` () =
         let dirs =
             [
-                testDir
+                TestHelpers.testPath
             ]
 
         let ast =
@@ -1429,6 +1428,3 @@ module FileImport =
             | _ -> false
             )
         |> should equal true
-
-
-

--- a/Parser.Test/TestParser.fs
+++ b/Parser.Test/TestParser.fs
@@ -1133,6 +1133,7 @@ module RegressionTests =
                     ])
             ])
 module Import =
+module StringImport =
 
     [<Fact>]
     let ``Resolve Import Statement`` () =
@@ -1384,3 +1385,50 @@ module Import =
                     ])
               ])
             ])
+
+
+[<Xunit.Trait("Kind", "Unit")>]
+module FileImport =
+
+    open System
+    open System.IO
+
+    let isMono = System.Type.GetType "Mono.Runtime" |> isNull |> not
+
+    /// gets the path for a test file based on the relative path from the executing assembly
+    let testDir =
+        let solutionPath =
+            if isMono then
+                "../../../"
+            else
+                let codeBase = Reflection.Assembly.GetExecutingAssembly().CodeBase
+                let assemblyPath = DirectoryInfo (Uri codeBase).LocalPath
+                (assemblyPath.Parent.Parent.Parent.Parent).FullName
+        Path.Combine(solutionPath, "test")
+
+    [<Fact>]
+    let ``Resolve File Import`` () =
+        let dirs =
+            [
+                testDir
+            ]
+
+        let ast =
+            dirs |> Parse.loadFromFile "riak_kv.proto"
+
+        // riak_kv.proto includes riak.proto
+        ast
+        |> List.length
+        |> should equal 2
+
+        // riak.proto contains a message definition for RpbGetServerInfoResp
+        let _, riakAst = ast.[1]
+        riakAst
+        |> List.exists(function
+            | TMessage( "RpbGetServerInfoResp", _ ) -> true
+            | _ -> false
+            )
+        |> should equal true
+
+
+

--- a/Parser.Test/TestParser.fs
+++ b/Parser.Test/TestParser.fs
@@ -1132,3 +1132,93 @@ module RegressionTests =
                         TField("corpus", TOptional, TIdent("Corpus"), 4u, [])
                     ])
             ])
+module Import =
+
+    [<Fact>]
+    let ``Resolve Import Statement`` () =
+        let src = """
+            syntax = "proto2";
+
+            import "import.proto";
+
+            message Test {
+                optional MyEnum a = 1;
+                }
+            """
+
+        let fetch = function
+            | "import.proto" ->
+                    """
+                    enum MyEnum {
+                        DEFAULT = 0;
+                        ONE = 1;
+                        }
+                    """
+            | s -> raise <| System.ArgumentOutOfRangeException(s)
+
+        let ast =
+            src
+            |> Parse.fromString
+            |> fun ast -> ("test.proto", ast)
+            |> Parse.resolveImports Parse.fromString fetch
+
+        ast |> should equal (
+            [ ("test.proto", [
+                TSyntax TProto2
+                TImport ("import.proto", TNormal)
+                TMessage ("Test",
+                    [
+                        TField ("a", TOptional, TIdent("MyEnum"), 1u, [])
+                    ])
+              ]);
+              ("import.proto", [
+                TEnum ("MyEnum",
+                    [
+                       TEnumField ("DEFAULT", 0, [])
+                       TEnumField ("ONE", 1, []) 
+                    ])
+              ])
+            ])
+
+    [<Fact>]
+    let ``Resolve Public Import Statement`` () =
+        let src = """
+            syntax = "proto2";
+
+            import public "import.proto";
+
+            message Test {
+                optional MyEnum a = 1;
+                }
+            """
+
+        let fetch = function
+            | "import.proto" ->
+                    """
+                    enum MyEnum {
+                        DEFAULT = 0;
+                        ONE = 1;
+                        }
+                    """
+            | s -> raise <| System.ArgumentOutOfRangeException(s)
+
+        let ast =
+            src
+            |> Parse.fromString
+            |> fun ast -> ("test.proto", ast)
+            |> Parse.resolveImports Parse.fromString fetch
+
+        ast |> should equal (
+            [ ("test.proto", [
+                TSyntax TProto2
+                TEnum ("MyEnum",
+                    [
+                       TEnumField ("DEFAULT", 0, [])
+                       TEnumField ("ONE", 1, []) 
+                    ])
+                TMessage ("Test",
+                    [
+                        TField ("a", TOptional, TIdent("MyEnum"), 1u, [])
+                    ])
+              ])
+            ])

--- a/Parser.Test/TestParser.fs
+++ b/Parser.Test/TestParser.fs
@@ -1243,7 +1243,7 @@ module Import =
             let aux = function
                 | "test.proto" ->
                     """
-                    import "missing.proto";
+                    import public "missing.proto";
                     """
                 | s -> raise <| System.IO.FileNotFoundException(s)
             (name, aux name)

--- a/Parser.Test/TestParser.fs
+++ b/Parser.Test/TestParser.fs
@@ -1146,26 +1146,30 @@ module Import =
                 }
             """
 
-        let fetch = function
-            | "import.proto" ->
-                    """
-                    enum MyEnum {
-                        DEFAULT = 0;
-                        ONE = 1;
-                        }
-                    """
-            | s -> raise <| System.ArgumentOutOfRangeException(s)
+        let fetch name =
+            let aux = function
+                | "import.proto" ->
+                        """
+                        enum MyEnum {
+                            DEFAULT = 0;
+                            ONE = 1;
+                            }
+                        """
+                | s -> raise <| System.IO.FileNotFoundException(s)
+            (name, aux name)
+
+        let parse (name, s) =
+            (name, Parse.fromString s)
 
         let ast =
             src
             |> Parse.fromString
             |> fun ast -> ("test.proto", ast)
-            |> Parse.resolveImports Parse.fromString fetch
+            |> Parse.resolveImports fetch parse
 
         ast |> should equal (
             [ ("test.proto", [
                 TSyntax TProto2
-                TImport ("import.proto", TNormal)
                 TMessage ("Test",
                     [
                         TField ("a", TOptional, TIdent("MyEnum"), 1u, [])
@@ -1181,6 +1185,83 @@ module Import =
             ])
 
     [<Fact>]
+    let ``Resolve Recursive Import Statements`` () =
+        let src = """
+            syntax = "proto2";
+
+            import "import.proto";
+
+            message Test {
+                optional MyEnum a = 1;
+                }
+            """
+
+        let fetch name =
+            let aux = function
+                | "import.proto" ->
+                        """
+                        import "inner.proto";
+                        """
+                | "inner.proto" ->
+                        """
+                        enum MyEnum {
+                            DEFAULT = 0;
+                            ONE = 1;
+                            }
+                        """
+                | s -> raise <| System.IO.FileNotFoundException(s)
+            (name, aux name)
+
+        let parse (name, s) =
+            (name, Parse.fromString s)
+
+        let ast =
+            src
+            |> Parse.fromString
+            |> fun ast -> ("test.proto", ast)
+            |> Parse.resolveImports fetch parse
+
+        ast |> should equal (
+            [ ("test.proto", [
+                TSyntax TProto2
+                TMessage ("Test",
+                    [
+                        TField ("a", TOptional, TIdent("MyEnum"), 1u, [])
+                    ])
+              ]);
+              ("import.proto", []);
+              ("inner.proto", [
+                TEnum ("MyEnum",
+                    [
+                       TEnumField ("DEFAULT", 0, [])
+                       TEnumField ("ONE", 1, []) 
+                    ])
+              ])
+            ])
+
+    [<Fact>]
+    let ``Missing import throws`` () =
+        let src = """
+            import "missing.proto";
+            """
+
+        let fetch name =
+            let aux = function
+                | s -> raise <| System.IO.FileNotFoundException(s)
+            (name, aux name)
+
+        let parse (name, s) =
+            (name, Parse.fromString s)
+
+        fun () ->
+            src
+            |> Parse.fromString
+            |> fun ast -> ("test.proto", ast)
+            |> Parse.resolveImports fetch parse
+            |> ignore
+        |> should throw typeof<System.IO.FileNotFoundException>
+
+    [<Fact>]
     let ``Resolve Public Import Statement`` () =
         let src = """
             syntax = "proto2";
@@ -1192,21 +1273,26 @@ module Import =
                 }
             """
 
-        let fetch = function
-            | "import.proto" ->
-                    """
-                    enum MyEnum {
-                        DEFAULT = 0;
-                        ONE = 1;
-                        }
-                    """
-            | s -> raise <| System.ArgumentOutOfRangeException(s)
+        let fetch name =
+            let aux = function
+                | "import.proto" ->
+                        """
+                        enum MyEnum {
+                            DEFAULT = 0;
+                            ONE = 1;
+                            }
+                        """
+                | s -> raise <| System.IO.FileNotFoundException(s)
+            (name, aux name)
+
+        let parse (name, s) =
+            (name, Parse.fromString s)
 
         let ast =
             src
             |> Parse.fromString
             |> fun ast -> ("test.proto", ast)
-            |> Parse.resolveImports Parse.fromString fetch
+            |> Parse.resolveImports fetch parse
 
         ast |> should equal (
             [ ("test.proto", [
@@ -1219,6 +1305,132 @@ module Import =
                 TMessage ("Test",
                     [
                         TField ("a", TOptional, TIdent("MyEnum"), 1u, [])
+                    ])
+              ])
+            ])
+
+    [<Fact>]
+    let ``Resolve recursive Public Import Statement`` () =
+        let src = """
+            syntax = "proto2";
+
+            import public "import.proto";
+
+            message Test {
+                optional MyEnum a = 1;
+                }
+            """
+
+        let fetch name =
+            let aux = function
+                | "import.proto" ->
+                        """
+                        import public "inner.proto";
+                        """
+                | "inner.proto" ->
+                        """
+                        enum MyEnum {
+                            DEFAULT = 0;
+                            ONE = 1;
+                            }
+                        """
+                | s -> raise <| System.IO.FileNotFoundException(s)
+            (name, aux name)
+
+        let parse (name, s) =
+            (name, Parse.fromString s)
+
+        let ast =
+            src
+            |> Parse.fromString
+            |> fun ast -> ("test.proto", ast)
+            |> Parse.resolveImports fetch parse
+
+        ast |> should equal (
+            [ ("test.proto", [
+                TSyntax TProto2
+                TEnum ("MyEnum",
+                    [
+                       TEnumField ("DEFAULT", 0, [])
+                       TEnumField ("ONE", 1, []) 
+                    ])
+                TMessage ("Test",
+                    [
+                        TField ("a", TOptional, TIdent("MyEnum"), 1u, [])
+                    ])
+              ])
+            ])
+
+    [<Fact>]
+    let ``Missing public import throws`` () =
+        let src = """
+            import "missing.proto";
+            """
+
+        let fetch name =
+            let aux = function
+                | s -> raise <| System.IO.FileNotFoundException(s)
+            (name, aux name)
+
+        let parse (name, s) =
+            (name, Parse.fromString s)
+
+        fun () ->
+            src
+            |> Parse.fromString
+            |> fun ast -> ("test.proto", ast)
+            |> Parse.resolveImports fetch parse
+            |> ignore
+        |> should throw typeof<System.IO.FileNotFoundException>
+
+
+    [<Fact>]
+    let ``Resolve Weak Import Statement and ignore missing weak import`` () =
+        let src = """
+            syntax = "proto2";
+
+            import weak "import.proto";
+            import weak "missing.proto";
+
+            message Test {
+                optional MyEnum a = 1;
+                }
+            """
+
+        let fetch name =
+            let aux = function
+                | "import.proto" ->
+                        """
+                        enum MyEnum {
+                            DEFAULT = 0;
+                            ONE = 1;
+                            }
+                        """
+                | s -> raise <| System.IO.FileNotFoundException(s)
+            (name, aux name)
+
+        let parse (name, s) =
+            (name, Parse.fromString s)
+
+        let ast =
+            src
+            |> Parse.fromString
+            |> fun ast -> ("test.proto", ast)
+            |> Parse.resolveImports fetch parse
+
+        ast |> should equal (
+            [ ("test.proto", [
+                TSyntax TProto2
+                TMessage ("Test",
+                    [
+                        TField ("a", TOptional, TIdent("MyEnum"), 1u, [])
+                    ])
+              ]);
+              ("import.proto", [
+                TEnum ("MyEnum",
+                    [
+                       TEnumField ("DEFAULT", 0, [])
+                       TEnumField ("ONE", 1, []) 
                     ])
               ])
             ])

--- a/Parser/Ast.fs
+++ b/Parser/Ast.fs
@@ -24,14 +24,14 @@ and PStatement =
             | TSyntax s -> sprintf "TSyntax %A" s
             | TImport (s,v) -> sprintf "TImport (\"%s\",%A)" s v
             | TPackage id -> sprintf "TPackage \"%s\"" id
-            | TOption (n,v) -> sprintf "TOption (%s,%A)" n v
+            | TOption (n,v) -> sprintf "TOption (\"%s\",%A)" n v
             | TMessage (id, xs) ->
-                sprintf "TMessage (%s,[%s]" id
+                sprintf "TMessage (\"%s\",[%s]" id
                     ( xs |> List.map (sprintf "%A")
                          |> List.reduce (sprintf "%s;%s") )
-            | TEnum (id, xs) -> sprintf "TEnum (%s,%A)" id xs
-            | TExtend (id,xs) -> sprintf "TEnum (%s,%A)" id xs
-            | TService (id,xs) -> sprintf "TService (%s,%A)" id xs
+            | TEnum (id, xs) -> sprintf "TEnum (\"%s\",%A)" id xs
+            | TExtend (id,xs) -> sprintf "TEnum (\"%s\",%A)" id xs
+            | TService (id,xs) -> sprintf "TService (\"%s\",%A)" id xs
 
 // TSyntax
 and PSyntax =

--- a/Parser/Parser.fs
+++ b/Parser/Parser.fs
@@ -721,3 +721,58 @@ module Parse =
     /// Parse proto from a file.  Throws System.FormatException on failure.
     let fromFile fileName =
         fromFileWithParser Parsers.pProto fileName
+
+    /// Resolve imports using provided `fetch` function, each parsed with supplied `parse` function.
+    /// Returns list of (filename, ast) tuples.
+    /// Public imports are replaced in-line.
+    /// Weak imports ignore failure to fetch the import.
+    /// TODO: Should `import weak "filename"` ignore ALL errors?  Or just FileNotFound?
+    let rec resolveImports
+                (parse:'a -> Ast.PProto)
+                (fetch: string -> 'a)
+                (name:string,source:Ast.PProto)
+                    : (string * Ast.PProto) list =
+
+        // First, resolve public imports
+        let rec insertPublic (xs:Ast.PProto) : Ast.PProto =
+            let processStatement x acc =
+                match x with
+                | Ast.TImport( name, Ast.TPublic ) ->
+                    let imp =
+                        name
+                        |> fetch
+                        |> parse
+                        |> insertPublic
+                    imp @ acc
+                | statement ->
+                    statement :: acc
+            List.foldBack processStatement xs []
+
+        // Next, try to resovle weak imports
+
+            // TODO: implement - same as loadImports, but ignore fetch exceptions
+
+        // Finally, resolve normal imports
+        let loadImports parse (xs:Ast.PProto) =
+            xs
+            |> List.choose (function
+                | Ast.TImport (name, Ast.TNormal) -> Some(name) 
+                | _ -> None
+                )
+            |> List.map (fun name ->
+                name
+                |> fetch
+                |> parse
+                |> fun ast -> (name, ast)
+                |> resolveImports parse fetch
+                )
+            |> List.concat
+
+        let source =
+            source
+            |> insertPublic
+
+        source
+        |> loadImports parse
+        |> fun imports -> (name, source) :: imports
+


### PR DESCRIPTION
Implement processing `import` statements from issue #48, Parser Improvements.

Adds support for import from strings, streams, and files. Further, it handles `normal`, `public`, and `weak` imports.